### PR TITLE
Move dependencies from Gemfile to gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,14 +2,3 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in notion-sdk-ruby.gemspec
 gemspec
-
-gem "httparty", "~> 0.18.1"
-
-group :development, :test do
-  gem "rake", "~> 12.0"
-  gem "rspec", "~> 3.0"
-  gem "standardrb", "~> 1.0"
-  gem "webmock", "~> 3.12"
-  gem "pry", "~> 0.14.1"
-  gem "dotenv", "~> 2.7"
-end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     notion-sdk-ruby (0.2.1)
+      httparty (~> 0.18.1)
 
 GEM
   remote: https://rubygems.org/
@@ -79,7 +80,6 @@ PLATFORMS
 
 DEPENDENCIES
   dotenv (~> 2.7)
-  httparty (~> 0.18.1)
   notion-sdk-ruby!
   pry (~> 0.14.1)
   rake (~> 12.0)

--- a/lib/notion/client.rb
+++ b/lib/notion/client.rb
@@ -2,6 +2,7 @@ module Notion
   class Client
     include Endpoints
     include HTTParty
+    headers 'Content-Type': 'application/json'
     base_uri "https://api.notion.com"
 
     def initialize(token:)

--- a/lib/notion/endpoints/blocks.rb
+++ b/lib/notion/endpoints/blocks.rb
@@ -6,7 +6,7 @@ module Notion
       end
 
       def append_block_children(id, body)
-        self.class.patch("/v1/blocks/#{id}/children", body: body)
+        self.class.patch("/v1/blocks/#{id}/children", body: body.to_json)
       end
     end
   end

--- a/lib/notion/endpoints/databases.rb
+++ b/lib/notion/endpoints/databases.rb
@@ -10,7 +10,7 @@ module Notion
       end
 
       def query_database(id, body)
-        self.class.post("/v1/databases/#{id}/query", body: body)
+        self.class.post("/v1/databases/#{id}/query", body: body.to_json)
       end
     end
   end

--- a/lib/notion/endpoints/pages.rb
+++ b/lib/notion/endpoints/pages.rb
@@ -6,11 +6,11 @@ module Notion
       end
 
       def create_page(body)
-        self.class.post("/v1/pages", body: body)
+        self.class.post("/v1/pages", body: body.to_json)
       end
 
       def update_page(id, body)
-        self.class.patch("/v1/pages/#{id}", body: body)
+        self.class.patch("/v1/pages/#{id}", body: body.to_json)
       end
     end
   end

--- a/lib/notion/endpoints/search.rb
+++ b/lib/notion/endpoints/search.rb
@@ -2,7 +2,7 @@ module Notion
   module Endpoints
     module Search
       def search(body)
-        self.class.post("/v1/search", body: body)
+        self.class.post("/v1/search", body: body.to_json)
       end
     end
   end

--- a/notion-sdk-ruby.gemspec
+++ b/notion-sdk-ruby.gemspec
@@ -23,4 +23,12 @@ Gem::Specification.new do |spec|
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+  
+  spec.add_dependency 'httparty', "~> 0.18.1"
+  spec.add_development_dependency 'rake', "~> 12.0"
+  spec.add_development_dependency 'rspec', "~> 3.0"
+  spec.add_development_dependency 'standardrb', "~> 1.0"
+  spec.add_development_dependency 'webmock', "~> 3.12"
+  spec.add_development_dependency 'pry', "~> 0.14.1"
+  spec.add_development_dependency 'dotenv', "~> 2.7"
 end


### PR DESCRIPTION
I tried to use the gem but the dependencies were not loaded because they were in `Gemfile` instead of the gemspec file.