### PR TITLE
Update docs related to Notion::List

### DIFF
--- a/lib/notion-sdk-ruby/api/blocks.rb
+++ b/lib/notion-sdk-ruby/api/blocks.rb
@@ -36,7 +36,7 @@ module Notion
       # https://developers.notion.com/reference/get-block-children
       # @param [String] id block_id
       # @param [Hash] query
-      # @return [Array<Notion::Block>]
+      # @return [Notion::List<Notion::Block>]
       def list(id, query = {})
         response = get("/v1/blocks/#{id}/children", query)
         List.new(response.body)
@@ -46,7 +46,7 @@ module Notion
       # https://developers.notion.com/reference/patch-block-children
       # @param [String] id block_id
       # @param [Hash] body
-      # @return [Array<Notion::Block>]
+      # @return [Notion::List<Notion::Block>]
       def append(id, body)
         response = patch("/v1/blocks/#{id}/children", body.to_json)
         List.new(response.body)

--- a/lib/notion-sdk-ruby/api/databases.rb
+++ b/lib/notion-sdk-ruby/api/databases.rb
@@ -17,7 +17,7 @@ module Notion
       # https://developers.notion.com/reference/post-database-query
       # @param [String] id database_id
       # @param [Hash] body
-      # @return [Array<Notion::Database>]
+      # @return [Notion::List<Notion::Database>]
       def query(id, body)
         response = post("/v1/databases/#{id}/query", body.to_json)
         List.new(response.body)

--- a/lib/notion-sdk-ruby/api/search.rb
+++ b/lib/notion-sdk-ruby/api/search.rb
@@ -7,7 +7,7 @@ module Notion
       # that are shared with the integration.
       # https://developers.notion.com/reference/post-search
       # @param [Hash] body
-      # @return [Array]
+      # @return [Notion::List<OpenStruct>]
       def search(body)
         response = post("/v1/search", body.to_json)
         List.new(response.body)

--- a/lib/notion-sdk-ruby/api/users.rb
+++ b/lib/notion-sdk-ruby/api/users.rb
@@ -5,7 +5,7 @@ module Notion
 
       # Returns a paginated list of Users for the workspace.
       # https://developers.notion.com/reference/get-users
-      # @return [Array<Notion::User>]
+      # @return [Notion::List<Notion::User>]
       def list
         response = get("/v1/users")
         List.new(response.body)


### PR DESCRIPTION
Hi guys, I love this gem since it provides clear APIs in the Ruby way.

However, [since Notion::List added](https://github.com/mgmarlow/notion-sdk-ruby/commit/137e472e5f698fb3d0bbf1beb73457cf4b0b7680), related docs have not been updated timely. This PR aims at fixing this point.