### PR TITLE
Fix `DatabaseMethods#query` return type

### DIFF
--- a/lib/notion-sdk-ruby/api/databases.rb
+++ b/lib/notion-sdk-ruby/api/databases.rb
@@ -17,7 +17,7 @@ module Notion
       # https://developers.notion.com/reference/post-database-query
       # @param [String] id database_id
       # @param [Hash] body
-      # @return [Notion::List<Notion::Database>]
+      # @return [Notion::List<Notion::Page>]
       def query(id, body)
         response = post("/v1/databases/#{id}/query", body.to_json)
         List.new(response.body)


### PR DESCRIPTION
The Database query API returns a list of pages not databases https://developers.notion.com/reference/post-database-query